### PR TITLE
fix: krzysio chr init workaround

### DIFF
--- a/scripts/patch_mmc3.py
+++ b/scripts/patch_mmc3.py
@@ -10,29 +10,82 @@ rom[5] = CHR_BANKS
 rom[6] = 0x41
 rom[7] = 0x08
 
-# dummy reset patch (credits: zohassadar)
-patch = bytearray([0xa2,0x06,0xa0,0x00,0x8e,0x00,0x80,0x8c,0x01,0x80,0xe8,0xc8,0x8e,0x00,0x80,0x8c,0x01,0x80,0x4c])
+# krzysio workaround
+patch = bytearray(
+    [
+        # intialize prg banks
+        0xA2,  # ldx #$06
+        0x06,
+        0xA0,  # ldy #$00
+        0x00,
+        0x8E,  # stx $8000
+        0x00,
+        0x80,
+        0x8C,  # sty $8001
+        0x01,
+        0x80,
+        0xE8,  # inx
+        0xC8,  # iny
+        0x8E,  # stx $8000
+        0x00,
+        0x80,
+        0x8C,  # sty $8001
+        0x01,
+        0x80,
+        # initialize chr $1000-$1FFF
+        0xA2,  # ldx #$02
+        0x02,
+        0xA0,  # ldy #$00
+        0x00,
+        0x8E,  # stx $8000
+        0x00,
+        0x80,
+        0x8C,  # sty $8001
+        0x01,
+        0x80,
+        0xE8,  # inx
+        0xC8,  # iny
+        0x8E,  # stx $8000
+        0x00,
+        0x80,
+        0x8C,  # sty $8001
+        0x01,
+        0x80,
+        0xE8,  # inx
+        0xC8,  # iny
+        0x8E,  # stx $8000
+        0x00,
+        0x80,
+        0x8C,  # sty $8001
+        0x01,
+        0x80,
+        0xE8,  # inx
+        0xC8,  # iny
+        0x8E,  # stx $8000
+        0x00,
+        0x80,
+        0x8C,  # sty $8001
+        0x01,
+        0x80,
+        0x4C,  # jmp
+    ]
+)
 
-"""
-    ldx #$06
-    ldy #$00
-    stx $8000
-    sty $8001
-    inx
-    iny
-    stx $8000
-    sty $8001
-    jmp $8161
-"""
+target = 0xFF00
+romtarget = target - 0x7FF0
 
-reset_lo = rom[0x800c]
-reset_hi = rom[0x800d]
+patch.extend(rom[0x800C:0x800E])
 
-patch.extend([reset_lo, reset_hi])
+# verify target is all zeroes
+if rom[romtarget : romtarget + len(patch)] != [0] * len(patch):
+    raise RuntimeError(
+        f"ROM space at ${target:04x} through ${target+len(patch):04x} is in use"
+    )
 
-rom[0x7f10:0x7f10+len(patch)] = patch
-rom[0x800c] = 0x00
-rom[0x800d] = 0xFF
+rom[romtarget : romtarget + len(patch)] = patch
+
+rom[0x800C] = target & 0xFF
+rom[0x800D] = target >> 8
 
 with open('roll.nes', 'wb') as f:
     f.write(bytearray(rom[:NEW_SIZE]))


### PR DESCRIPTION
It appears as though krzysiocart initializes the 4 1k CHR banks at $1000 through $1FFF with the same data, causing sprite related bugs when running on that platform.  This adds an initialization for those banks to the existing PRG patch.   This also adds a safety net so that in the off chance the address space at $ff00 is in use, an exception will be raised.  